### PR TITLE
feat: Implement Lalamove order processing and meta box in WooCommerce

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -48,9 +48,9 @@ Override wordpress style
 }
 
 #wpbody-content {
-    position: fixed; /* Fix the position */
-    width: 90%;
     height: auto;
     overflow: hidden; /* Prevent content from overflowing */
+    box-sizing: border-box;
+
 }
 

--- a/assets/js/lalamove-metabox.js
+++ b/assets/js/lalamove-metabox.js
@@ -1,0 +1,54 @@
+jQuery(function($) {
+  console 
+  $(document).on('click', '.transfer-to-lalamove-btn', function(e) {
+    e.preventDefault();
+
+    var $btn    = $(this),
+        orderId = $btn.data('order_id'),
+        nonce   = $btn.data('nonce');
+
+    $btn.prop('disabled', true).text('Transferring…');
+
+
+    jQuery.ajax({
+    url: wooLalamoveMetabox.ajax_url,
+    method: "POST",
+    data: {
+        action   : "push_send_to_lalamove",
+        order_id : orderId,
+        nonce    : nonce
+    },
+    success: function(response) {
+        console.log("RESPONSE", response);
+        if (response.success) {
+        alert(
+            "✅ Order #" + orderId +
+            " has been pushed. You’ll now be redirected to the Lalamove menu."
+        );
+
+        //Redirect to lalamove orders
+        window.location.href = window.location.origin + "/wp-admin/admin.php?page=woo-lalamove#/orders";
+        
+        } else {
+        console.error("ERROR", response.data);
+        alert(
+            "❌ Transfer failed: " + response.data + "\n" +
+            "Please try again."
+        );
+        $btn.prop("disabled", false).text("Transfer to Lalamove");
+        }
+    },
+    error: function(response, error, xhr) {
+        console.log("RESPONSE", response);
+        console.error("MAY MALI!!!", error);
+        console.error("XHR Response Text:", xhr.responseText);
+        alert(
+        "🚨 Unable to reach the server.\n" +
+        "Check your network and try again."
+        );
+        $btn.prop("disabled", false).text("Transfer to Lalamove");
+    }
+    });
+
+  });
+});

--- a/assets/js/vue/components/Navbar.vue
+++ b/assets/js/vue/components/Navbar.vue
@@ -23,12 +23,12 @@
       <span class="nav-item__label">Records</span>
     </router-link>
 
-    <router-link 
+    <!-- <router-link 
       to="/dashboard" 
       class="nav-item nav-item--dashboard"
     >
       <span class="nav-item__label">Dashboard</span>
-    </router-link>
+    </router-link> -->
 
     <!-- <div class="nav-controls">
       <router-link 

--- a/assets/js/vue/components/PlaceOrder/ScheduleDate.vue
+++ b/assets/js/vue/components/PlaceOrder/ScheduleDate.vue
@@ -40,6 +40,8 @@ function validateScheduleDate() {
   const date = moment(localSchedule.value);
   const selectedHour = date.hour();
 
+  console.log("date: ", selectedHour);
+
   if (selectedHour < BUSINESS_HOURS.START || selectedHour > BUSINESS_HOURS.END) {
     toast.error("Delivery hours are 8 AM - 4 PM. Please select a valid time.");
     localSchedule.value = minDate.value;
@@ -53,16 +55,15 @@ onMounted(() => {
   const startDate = moment().add(1, 'days').startOf('day').add(BUSINESS_HOURS.START, 'hours');
   const endDate = moment().add(30, 'days').startOf('day').add(BUSINESS_HOURS.END, 'hours');
 
-  console.log("SCHEDULE: ", scheduleAt.value);
 
   // Set ISO format in store
   if(scheduleAt.value !== ""){
     localSchedule.value = scheduleAt.value.replace(' ', 'T').slice(0, 16);
   } else {
-    console.log("WHAT IS THIS")
     scheduleAt.value = startDate.toISOString();
+    console.log("BOWM: ", scheduleAt.value);
     localSchedule.value = startDate.format('YYYY-MM-DDTHH:mm');
-  }
+}
   
   minDate.value = startDate.format('YYYY-MM-DDTHH:mm');
   maxDate.value = endDate.format('YYYY-MM-DDTHH:mm');
@@ -72,6 +73,9 @@ onMounted(() => {
 watch(scheduleAt, (newValue) => {
   if (newValue) {
     localSchedule.value = isoToLocal(newValue);
+  }
+  if (!newValue) {
+    scheduleAt.value = localToISO(localSchedule);
   }
 });
 </script>

--- a/assets/js/vue/store/lalamoveStore.js
+++ b/assets/js/vue/store/lalamoveStore.js
@@ -90,10 +90,7 @@ export const useLalamoveStore = defineStore("lalamove", () => {
           phone: senderAddress.phone,
         },
         recipients,
-        isPODEnabled: isPodEnabled.value,
-        ...(additionalNotes.value && {
-          additionalNotes: additionalNotes.value,
-        }),
+        isPODEnabled: isPodEnabled.value
       },
     };
   });
@@ -111,7 +108,6 @@ export const useLalamoveStore = defineStore("lalamove", () => {
 
   const canRequestQuote = computed(
     () =>
-      scheduleAt.value !== "" &&
       serviceType.value !== "" &&
       addresses.length >= 2 &&
       item.value.quantity !== "" &&
@@ -360,7 +356,7 @@ export const useLalamoveStore = defineStore("lalamove", () => {
         }
       }
 
-      console.log("Order Placement Response: ", response.data.data);
+      console.log("Order Placement Response: ", response.data);
       
       const { orderId, priceBreakdown } = response.data.data;
 

--- a/assets/js/vue/views/PlaceOrder.vue
+++ b/assets/js/vue/views/PlaceOrder.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="wrapper">
     <div class="content">
-      <div class="message">Message</div>
+      <!-- <div class="message">Message</div> -->
       <div class="content-1">
         <AddressInput class="address" />
 
@@ -135,12 +135,12 @@ onMounted(() => {
   height: 80%;
   width: 90%;
 
-  .message {
-    grid-area: 1 / 1 / 2 / 3;
-  }
+  // .message {
+  //   grid-area: 1 / 1 / 2 / 3;
+  // }
 
   .content-1 {
-    grid-area: 2 / 1 / 3 / 2;
+    grid-area: 1 / 1 / 2 / 2;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -149,7 +149,7 @@ onMounted(() => {
   }
 
   .content-2 {
-    grid-area: 2 / 2 / 3 / 3;
+    grid-area: 1 / 2 / 2 / 3;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -188,7 +188,7 @@ onMounted(() => {
   .content {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: 10% auto;
+    grid-template-rows: auto;
     grid-column-gap: 50px;
     grid-row-gap: 15px;
   }

--- a/assets/js/vue/views/RecordsDetails.vue
+++ b/assets/js/vue/views/RecordsDetails.vue
@@ -1,338 +1,394 @@
 <template>
-
-    <div class="details-wrapper">
-        <header v-if="status == 'ASSIGNING_DRIVER'">
-
-            <div class="transaction-info" style="background-color: #FEF9E1; border: 2px solid #FFF2B1;">
-                    <p>
-                        Assigning Driver  ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: {{ scheduleData }}
-                    </p>
-            </div>
-
-            <div class="header-content">
-
-                <h3>Finding Nearby</h3>
-                <p>Please wait a moment</p>
-
-                <div class="action-container">
-                    <button @click="openShareLink" class="action-button">
-                        <span class="material-symbols-outlined header-icon">location_searching</span>
-                        Track Order
-                    </button>
-                    <button v-if="isCancelAvailable" @click="cancelOrder(lalaOrderId)" class="action-button">
-                        <span class="material-symbols-outlined footer-icon">close</span>
-                        Cancel Order
-                    </button>
-                    <!-- <button @click="addPriorityFee" class="action-button">
-                        <span class="material-symbols-outlined header-icon">add</span>
-                        Add Priority Fee
-                    </button> -->
-                </div>
-
-            </div>
-            
-        </header>
-        <header v-if="status == 'ON_GOING'">
-
-            <div class="transaction-info" style="background-color: #E0F0FD; border-color: 2px solid #5578B1; color: #5578B1;">
-                    <p>
-                        Awaiting Driver  ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: {{ scheduleData }} 
-                    </p>
-            </div>
-
-            <div class="header-content">
-
-                <h3>{{ driverName }}</h3>
-                <p>Plate Number: {{ driverPlateNumber }}</p>
-                <p>Contact Number: {{ driverContactNo }}</p>
-
-                <div class="action-container">
-                    <button @click="openShareLink"  class="action-button">
-                        <span class="material-symbols-outlined header-icon">location_searching</span>
-                        Track Order
-                    </button>
-                    <!-- <button onclick="window.open('https://example.com', '_blank')" class="action-button">
-                        <span class="material-symbols-outlined header-icon">swap_driving_apps</span>
-                        Change Driver
-                    </button> -->
-                    <button v-if="isCancelAvailable"  @click="cancelOrder(lalaOrderId)" class="action-button">
-                        <span class="material-symbols-outlined footer-icon">close</span>
-                        Cancel Order
-                    </button>
-                    <p class="delivery message">The driver is on its way to pick up the order</p>
-                </div>
-
-            </div>
-
-        </header>
-        <header v-if="status == 'PICKED_UP'">
-
-            <div class="transaction-info" style="background-color: #FFEEEF; border-color: 2px solid #F16622; color: #F16622;">
-                    <p>
-                        Picked Up  ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: 10 Dec 2024 5:55PM
-                    </p>
-            </div>
-
-            <div class="header-content">
-
-                <h3>{{ driverName }}</h3>
-                <p>Plate Number: {{ driverPlateNumber }}</p>
-                <p>Contact Number: {{ driverContactNo }}</p>
-
-                <div class="action-container">
-                    <button @click="openShareLink" class="action-button">
-                        <span class="material-symbols-outlined header-icon">location_searching</span>
-                        Track Order
-                    </button>
-                    <!-- <button onclick="window.open('https://example.com', '_blank')" class="action-button">
-                        <span class="material-symbols-outlined header-icon">swap_driving_apps</span>
-                        Change Driver
-                    </button> -->
-                    <p class="delivery message">The driver picked up the order</p>
-                </div>
-
-            </div>
-
-        </header>
-        <header v-if="status == 'COMPLETED'">
-            <div class="transaction-info" style="background-color: #DBFFE3; border-color: 2px solid #05B32B; color: #05B32B;">
-                    <p>
-                        Completed ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: 10 Dec 2024 5:55PM
-                    </p>
-            </div>
-
-            <div class="header-content">
-
-                <h3>{{ driverName }}</h3>
-                <p>Plate Number: {{ driverPlateNumber }}</p>
-                <p>Contact Number: {{ driverContactNo }}</p>
-
-                <div class="action-container">
-                    <button @click="openShareLink" class="action-button">
-                        <span class="material-symbols-outlined header-icon">location_searching</span>
-                        Track Order
-                    </button>
-                </div>
-
-            </div>
-        </header>
-        <header v-if="status == 'REJECTED'">
-            <div class="transaction-info" style="background-color: #FFEEEF; border-color: 2px solid #CB3F49; color: #CB3F49;">
-                    <p>
-                        Rejected ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: 10 Dec 2024 5:55PM
-                    </p>
-            </div>
--
-            <div class="header-content">
-
-                <h3>Ordered Rejected</h3>
-                <p>The order was rejected twice.</p>
-
-            </div>
-        </header>
-        <header v-if="status == 'CANCELED'">
-            <div class="transaction-info" style="background-color: #FFEEEF; border-color: 2px solid #CB3F49; color: #CB3F49;">
-                    <p>
-                        Canceled ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: 10 Dec 2024 5:55PM
-                    </p>
-            </div>
--
-            <div class="header-content">
-
-                <h3>Ordered Canceled</h3>
-                <p>The order has been canceled or rejected by the driver twice.</p>
-
-            </div>
-        </header>
-        <header v-if="status == 'EXPIRED'">
-            <div class="transaction-info" style="background-color: #EDEDED; border-color: 2px solid #4C4C4C; color: #4C4C4C;">
-                    <p>
-                        Expired ●  {{ lalaOrderId }}
-                    </p>
-                    <p>
-                        Schedule Date: 10 Dec 2024 5:55PM
-                    </p>
-            </div>  
--
-            <div class="header-content">
-
-                <h3>Order Expired</h3>
-                <p>The order expired after the driver failed to accept it within two hours.</p>
-
-            </div>
-        </header>
-
-        <div v-if="noData" class="no-record">
-            <h1>
-                No records found
-            </h1>
+  <div class="details-wrapper">
+    <!-- Status Header -->
+    <header v-if="!loading && !noData && status == 'ASSIGNING_DRIVER'" class="status-header">
+      <div class="status-card assigning">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Assigning Driver</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
         </div>
-
-        <main v-else>
-            <h3>ROUTE</h3>
-            <div class="location-wrapper">
-                <div class="box">
-                    <span class="material-symbols-outlined body-icon">brightness_1</span>
-                    <span class="location">
-                        <p>
-                            Pickup Location
-                        </p>
-                        <p>
-                            {{ senderAddress }}
-                        </p>
-                        <p>
-                            {{ senderName }} - {{ senderPhoneNo }}
-                        </p>
-                    </span>
-                </div>
-
-                    <div class="line"></div>
-
-                <div class="box">
-                    <span class="material-symbols-outlined body-icon">location_on</span>
-
-                    <span class="location">
-                        <p>
-                            Drop Off Location
-                        </p>
-                        <p>
-                            {{ customerAddress }}
-                        </p>
-                        <p>
-                            {{ customerName }} - {{ customerPhoneNo }}
-                        </p>
-                    </span>
-                </div>
-
-            </div>
-
-            <div class="additional-info-wrapper">
-
-                
-                <div class="additional-info">
-                <strong>
-                    Placed By
-                </strong>
-                
-                <p>
-                    {{ senderName }}
-                </p>
-            </div>
-            <div class="additional-info">
-                <strong>
-                    Service Type
-                </strong>
-                
-                <p>
-                    {{ serviceType }}
-                </p>
-            </div>
-            <!-- <div class="additional-info">
-                <strong>
-                    Additional Services
-                </strong>
-                
-                <p>
-                    dummy data
-                </p>
-            </div> -->
-
-
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="status-message">
+          <h3>🔍 Finding Nearby Driver</h3>
+          <p>Please wait while we assign a driver to your order</p>
         </div>
-
-
-        <div class="price-breakdown">
-            <h3>PRICE</h3>
-
-                <span v-if="basePrice" class="cost">
-                    <p>Base Price</p>
-                    <p class="cost-price">
-                        {{ basePrice }}
-                    </p>
-                </span>
-                <span v-if="extraMileage" class="cost">
-                    <p>Additional Distance Fee</p>
-                    <p class="cost-price">
-                        {{ extraMileage }}
-                    </p>
-                </span>
-                <span v-if="specialRequest" class="cost">
-                    <p>Special Request Fee</p>
-                    <p class="cost-price">
-                        {{ specialRequest }}
-                    </p>
-                </span>
-                <span v-if="priorityFee" class="cost">
-                    <p>Priority Fee</p>
-                    <p class="cost-price">
-                        {{ priorityFee }}
-                    </p>
-                </span>
-                <span v-if="surcharge" class="cost"> 
-                    <p>Surcharge</p>
-                    <p class="cost-price">
-                        {{ surcharge }}
-                    </p>
-                </span>
-                <span v-if="totalExcludedPriorityFee" class="cost">
-                    <p>Total Exluded Priority Fee</p>
-                    <p class="total-price">
-                        {{ totalExcludedPriorityFee }}
-                    </p>
-                </span>
-                <span  class="cost"> 
-                    <p>Total</p>
-                    <p class="total-price">
-                        {{ total }}
-                    </p>
-                </span>
+        
+        <div class="action-buttons">
+          <button @click="openShareLink" class="btn-primary">
+            <span class="material-symbols-outlined">location_searching</span>
+            Track Order
+          </button>
+          <button v-if="isCancelAvailable" @click="cancelOrder(lalaOrderId)" class="btn-secondary">
+            <span class="material-symbols-outlined">close</span>
+            Cancel Order
+          </button>
         </div>
+      </div>
+    </header>
 
-        <div v-if="podImage" class="pod">
-            <img src="{{podImage}}" alt="">
+    <header v-if="!loading && !noData && status == 'ON_GOING'" class="status-header">
+      <div class="status-card ongoing">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Driver Assigned</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
         </div>
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="driver-info">
+          <h3>👨‍🚗 {{ driverName }}</h3>
+          <div class="driver-details">
+            <p><strong>Plate:</strong> {{ driverPlateNumber }}</p>
+            <p><strong>Contact:</strong> {{ driverContactNo }}</p>
+          </div>
+        </div>
+        
+        <div class="status-message pickup">
+          <p>🚗 The driver is on their way to pick up your order</p>
+        </div>
+        
+        <div class="action-buttons">
+          <button @click="openShareLink" class="btn-primary">
+            <span class="material-symbols-outlined">location_searching</span>
+            Track Order
+          </button>
+          <button v-if="isCancelAvailable" @click="cancelOrder(lalaOrderId)" class="btn-secondary">
+            <span class="material-symbols-outlined">close</span>
+            Cancel Order
+          </button>
+        </div>
+      </div>
+    </header>
 
+    <header v-if="!loading && !noData && status == 'PICKED_UP'" class="status-header">
+      <div class="status-card picked-up">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Picked Up</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
+        </div>
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="driver-info">
+          <h3>👨‍🚗 {{ driverName }}</h3>
+          <div class="driver-details">
+            <p><strong>Plate:</strong> {{ driverPlateNumber }}</p>
+            <p><strong>Contact:</strong> {{ driverContactNo }}</p>
+          </div>
+        </div>
+        
+        <div class="status-message delivery">
+          <p>📦 Your order has been picked up and is on the way!</p>
+        </div>
+        
+        <div class="action-buttons">
+          <button @click="openShareLink" class="btn-primary">
+            <span class="material-symbols-outlined">location_searching</span>
+            Track Order
+          </button>
+        </div>
+      </div>
+    </header>
 
+    <header v-if="!loading && !noData && status == 'COMPLETED'" class="status-header">
+      <div class="status-card completed">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Completed</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
+        </div>
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="driver-info">
+          <h3>👨‍🚗 {{ driverName }}</h3>
+          <div class="driver-details">
+            <p><strong>Plate:</strong> {{ driverPlateNumber }}</p>
+            <p><strong>Contact:</strong> {{ driverContactNo }}</p>
+          </div>
+        </div>
+        
+        <div class="status-message success">
+          <p>✅ Order delivered successfully!</p>
+        </div>
+        
+        <div class="action-buttons">
+          <button @click="openShareLink" class="btn-primary">
+            <span class="material-symbols-outlined">receipt_long</span>
+            View Details
+          </button>
+        </div>
+      </div>
+    </header>
 
+    <header v-if="!loading && !noData && status == 'REJECTED'" class="status-header">
+      <div class="status-card rejected">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Order Rejected</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
+        </div>
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="status-message error">
+          <h3>❌ Order Rejected</h3>
+          <p>Your order was rejected twice by drivers. Please try placing a new order.</p>
+        </div>
+      </div>
+    </header>
 
-            
-        </main>
+    <header v-if="!loading && !noData && status == 'CANCELED'" class="status-header">
+      <div class="status-card canceled">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Order Canceled</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
+        </div>
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="status-message error">
+          <h3>🚫 Order Canceled</h3>
+          <p>Your order has been canceled or rejected by drivers twice.</p>
+        </div>
+      </div>
+    </header>
 
-        <footer>
-            <div class="action-container">
-                <button @click="$router.push({ name: 'records' })" class="action-button" style="margin-right: auto;">
-                    <span class="material-symbols-outlined footer-icon">chevron_left</span>
-                    Return
-                </button>
+    <header v-if="!loading && !noData && status == 'EXPIRED'" class="status-header">
+      <div class="status-card expired">
+        <div class="status-indicator">
+          <span class="status-dot"></span>
+          <div class="status-text">
+            <h4>Order Expired</h4>
+            <p class="order-id">{{ lalaOrderId }}</p>
+          </div>
+        </div>
+        <p class="schedule-date">{{ scheduleData }}</p>
+      </div>
+      
+      <div class="header-content">
+        <div class="status-message warning">
+          <h3>⏰ Order Expired</h3>
+          <p>The order expired after no driver accepted it within two hours.</p>
+        </div>
+      </div>
+    </header>
 
-
-                    <!-- <button v-if="isOrderAgainAvailable" onclick="window.open('https://example.com', '_blank')" class="action-button">
-                        <span class="material-symbols-outlined footer-icon">reply</span>
-                        Order Again
-                    </button> -->
+    <!-- Skeleton Loader -->
+    <div v-if="loading && !noData" class="skeleton-wrapper">
+      <div class="skeleton-header">
+        <div class="skeleton-status-card">
+          <div class="skeleton-indicator">
+            <div class="skeleton-dot"></div>
+            <div class="skeleton-text">
+              <div class="skeleton-line skeleton-line-lg"></div>
+              <div class="skeleton-line skeleton-line-sm"></div>
             </div>
-        </footer>
-
+          </div>
+          <div class="skeleton-line skeleton-line-md"></div>
+        </div>
+        
+        <div class="skeleton-content">
+          <div class="skeleton-line skeleton-line-lg"></div>
+          <div class="skeleton-line skeleton-line-md"></div>
+          <div class="skeleton-buttons">
+            <div class="skeleton-button"></div>
+            <div class="skeleton-button"></div>
+          </div>
+        </div>
+      </div>
+      
+      <div class="skeleton-main">
+        <div class="skeleton-section">
+          <div class="skeleton-line skeleton-line-lg"></div>
+          <div class="skeleton-timeline">
+            <div class="skeleton-location">
+              <div class="skeleton-marker"></div>
+              <div class="skeleton-details">
+                <div class="skeleton-line skeleton-line-md"></div>
+                <div class="skeleton-line skeleton-line-lg"></div>
+                <div class="skeleton-line skeleton-line-sm"></div>
+              </div>
+            </div>
+            <div class="skeleton-location">
+              <div class="skeleton-marker"></div>
+              <div class="skeleton-details">
+                <div class="skeleton-line skeleton-line-md"></div>
+                <div class="skeleton-line skeleton-line-lg"></div>
+                <div class="skeleton-line skeleton-line-sm"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        <div class="skeleton-info-grid">
+          <div class="skeleton-card">
+            <div class="skeleton-line skeleton-line-sm"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+          <div class="skeleton-card">
+            <div class="skeleton-line skeleton-line-sm"></div>
+            <div class="skeleton-line skeleton-line-md"></div>
+          </div>
+        </div>
+        
+        <div class="skeleton-section">
+          <div class="skeleton-line skeleton-line-lg"></div>
+          <div class="skeleton-price-list">
+            <div class="skeleton-price-item" v-for="n in 4" :key="n">
+              <div class="skeleton-line skeleton-line-md"></div>
+              <div class="skeleton-line skeleton-line-sm"></div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+
+    <!-- No Data State -->
+    <div v-else-if="noData" class="no-record">
+      <div class="no-data-content">
+        <span class="material-symbols-outlined no-data-icon">receipt_long</span>
+        <h2>No Order Found</h2>
+        <p>We couldn't find any records for this order.</p>
+      </div>
+    </div>
+
+    <!-- Main Content -->
+    <main v-else-if="!loading" class="main-content">
+      <!-- Route Section -->
+      <section class="route-section">
+        <h3 class="section-title">
+          <span class="material-symbols-outlined">route</span>
+          ROUTE
+        </h3>
+        
+        <div class="location-timeline">
+          <div class="location-item pickup">
+            <div class="location-marker">
+              <span class="material-symbols-outlined">radio_button_checked</span>
+            </div>
+            <div class="location-details">
+              <h4>Pickup Location</h4>
+              <p class="address">{{ senderAddress }}</p>
+              <p class="contact">{{ senderName }} • {{ senderPhoneNo }}</p>
+            </div>
+          </div>
+
+          <div class="route-line"></div>
+
+          <div class="location-item dropoff">
+            <div class="location-marker">
+              <span class="material-symbols-outlined">location_on</span>
+            </div>
+            <div class="location-details">
+              <h4>Drop Off Location</h4>
+              <p class="address">{{ customerAddress }}</p>
+              <p class="contact">{{ customerName }} • {{ customerPhoneNo }}</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Order Info Section -->
+      <section class="info-section">
+        <div class="info-grid">
+          <div class="info-card">
+            <h4>Placed By</h4>
+            <p>{{ senderName }}</p>
+          </div>
+          <div class="info-card">
+            <h4>Service Type</h4>
+            <p>{{ serviceType }}</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Price Breakdown Section -->
+      <section class="price-section">
+        <h3 class="section-title">
+          <span class="material-symbols-outlined">payments</span>
+          PRICE BREAKDOWN
+        </h3>
+        
+        <div class="price-list">
+          <div v-if="basePrice" class="price-item">
+            <span>Base Price</span>
+            <span class="price">{{ basePrice }}</span>
+          </div>
+          <div v-if="extraMileage" class="price-item">
+            <span>Additional Distance Fee</span>
+            <span class="price">{{ extraMileage }}</span>
+          </div>
+          <div v-if="specialRequest" class="price-item">
+            <span>Special Request Fee</span>
+            <span class="price">{{ specialRequest }}</span>
+          </div>
+          <div v-if="priorityFee" class="price-item">
+            <span>Priority Fee</span>
+            <span class="price">{{ priorityFee }}</span>
+          </div>
+          <div v-if="surcharge" class="price-item">
+            <span>Surcharge</span>
+            <span class="price">{{ surcharge }}</span>
+          </div>
+          <div v-if="totalExcludedPriorityFee" class="price-item subtotal">
+            <span>Subtotal</span>
+            <span class="price">{{ totalExcludedPriorityFee }}</span>
+          </div>
+          <div class="price-item total">
+            <span>Total</span>
+            <span class="price">{{ total }}</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Proof of Delivery -->
+      <section v-if="podImage" class="pod-section">
+        <h3 class="section-title">
+          <span class="material-symbols-outlined">photo_camera</span>
+          PROOF OF DELIVERY
+        </h3>
+        <div class="pod-image">
+          <img :src="podImage" alt="Proof of Delivery" />
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="footer">
+      <button @click="$router.push({ name: 'records' })" class="btn-back">
+        <span class="material-symbols-outlined">arrow_back</span>
+        Back to Orders
+      </button>
+    </footer>
+  </div>
 </template>
+
+
 
 <script setup>
 import {ref, onMounted} from 'vue';
@@ -393,6 +449,8 @@ const props = defineProps({
 const fetchLalaOrderData = async (lala_id) => {
     
     try {
+        loading.value = true;
+
         const orderResponse = await axios.get(
             wooLalamoveAdmin.root + 'woo-lalamove/v1/get-lala-order-details/?lala_id=' + lala_id,
             {
@@ -463,18 +521,6 @@ const fetchLalaOrderData = async (lala_id) => {
             
         );
         
-        const driver = driverResponse.data;
-        
-        if(driver.errors){
-            return;
-        } else {
-            console.log("DRIVER RESPONSE: ", driver);
-
-            driverName.value = driver.name;
-            driverContactNo.value = driver.phone;
-            driverPlateNumber.value = driver.plateNumber;
-        }
-
 
         const lalaOrderBody = await axios.get(
             wooLalamoveAdmin.root + 'woo-lalamove/v1/lalamove-order-body/?lala_id=' + lala_id ,
@@ -501,8 +547,22 @@ const fetchLalaOrderData = async (lala_id) => {
 
         lalaOrderBody.value = lalaOrderBody.data[0].order_json_body;
 
+        const driver = driverResponse.data.data;
+        
+        if(!driver || driver.errors){
+          loading.value = false;
+            return;
+        } else {
+            console.log("DRIVER RESPONSE: ", driver);
+
+            driverName.value = driver.name;
+            driverContactNo.value = driver.phone;
+            driverPlateNumber.value = driver.plateNumber;
+        }
+
+        loading.value = false;
     } catch (error) {
-      console.error('Error fetching Woo Lalamove Orders:', error.response?.data || error.message);
+      console.error('Error fetching Woo Lalamove Orders:', error);
         noData.value = true;
     } 
 
@@ -551,228 +611,801 @@ onMounted(() => {
     fetchLalaOrderData(props.lala_id, props.wc_id);
 });
 
-
-
-
-
-
-
 </script>
+
+
 
 <style lang="scss" scoped>
 @use "@/css/scss/_variables.scss" as *;
+@use 'sass:color';
 
-.details-wrapper{
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-direction: column;
-    height: 100%;
-    background-color: $bg-light;
-    overflow-y: scroll;
+.details-wrapper {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  padding: 1rem;
+  padding-bottom: 10rem;
 
-    header {
+  @media (max-width: 768px) {
+    padding: 0.5rem;
+    padding-bottom: 5rem;
+  }
+}
+
+// Status Header Styles
+.status-header {
+  max-width: 900px;
+  margin: 0 auto 2rem auto;
+  
+  .status-card {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    margin-bottom: 1rem;
+    border-left: 4px solid;
+    
+    @media (max-width: 768px) {
+      padding: 1rem;
+      border-radius: 8px;
+    }
+    
+    &.assigning {
+      border-left-color: #FFF2B1;
+      background: #FEF9E1;
+      border: 2px solid #FFF2B1;
+    }
+    
+    &.ongoing {
+      border-left-color: #5578B1;
+      background: #E0F0FD;
+      border: 2px solid #5578B1;
+    }
+    
+    &.picked-up {
+      border-left-color: #F16622;
+      background: #FFEEEF;
+      border: 2px solid #F16622;
+    }
+    
+    &.completed {
+      border-left-color: #05B32B;
+      background: #DBFFE3;
+      border: 2px solid #05B32B;
+    }
+    
+    &.rejected, &.canceled {
+      border-left-color: #CB3F49;
+      background: #FFEEEF;
+      border: 2px solid #CB3F49;
+    }
+    
+    &.expired {
+      border-left-color: #4C4C4C;
+      background: #EDEDED;
+      border: 2px solid #4C4C4C;
+    }
+    
+    .status-indicator {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 0.5rem;
+      
+      .status-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        animation: pulse 2s infinite;
+        
+        .assigning & { background: #FFF2B1; }
+        .ongoing & { background: #5578B1; }
+        .picked-up & { background: #F16622; }
+        .completed & { background: #05B32B; }
+        .rejected &, .canceled & { background: #CB3F49; }
+        .expired & { background: #4C4C4C; }
+      }
+      
+      .status-text {
+        h4 {
+          margin: 0;
+          font-size: 1.25rem;
+          font-weight: 600;
+          color: #1f2937;
+        }
+        
+        .order-id {
+          margin: 0;
+          font-size: 0.875rem;
+          color: #6b7280;
+        }
+      }
+    }
+    
+    .schedule-date {
+      font-size: 0.875rem;
+      color: #4b5563;
+      margin: 0;
+      font-weight: 500;
+    }
+  }
+  
+  .header-content {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+    
+    @media (max-width: 768px) {
+      padding: 1rem;
+      border-radius: 8px;
+    }
+    
+    .status-message {
+      margin-bottom: 1.5rem;
+      text-align: center;
+      
+      h3 {
+        margin: 0 0 0.5rem 0;
+        font-size: 1.25rem;
+        color: $txt-primary;
+      }
+      
+      p {
+        margin: 0;
+        color: #6b7280;
+      }
+      
+      &.pickup, &.delivery {
+        background: #f0f9ff;
+        padding: 1rem;
+        border-radius: 8px;
+        border: 1px solid #e0f2fe;
+      }
+      
+      &.success {
+        background: #f0fdf4;
+        padding: 1rem;
+        border-radius: 8px;
+        border: 1px solid #dcfce7;
+      }
+      
+      &.error {
+        background: #fef2f2;
+        padding: 1rem;
+        border-radius: 8px;
+        border: 1px solid #fecaca;
+      }
+      
+      &.warning {
+        background: #fffbeb;
+        padding: 1rem;
+        border-radius: 8px;
+        border: 1px solid #fed7aa;
+      }
+    }
+    
+    .driver-info {
+      margin-bottom: 1.5rem;
+      text-align: center;
+      
+      h3 {
+        margin: 0 0 1rem 0;
+        font-size: 1.25rem;
+        color: $txt-primary;
+      }
+      
+      .driver-details {
         display: flex;
         justify-content: center;
-        align-items: center;
-        flex-direction: column;
-        width: 100%;
-        margin-top: 1rem;
-        padding: 0 1%;
-
-        .transaction-info{
-            width: 800px;
-            height: 50px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 0 1%;
-            border-radius: 3px;
+        gap: 2rem;
+        
+        @media (max-width: 768px) {
+          flex-direction: column;
+          gap: 0.5rem;
         }
         
-        .header-content{
-
-            width: 800px;
-            padding: 1rem;
-            border-bottom: 1px solid $border-color;
-
+        p {
+          margin: 0;
+          color: #6b7280;
+          font-size: 0.875rem;
         }
+      }
     }
-    main{
-        flex: 1;
-        display: flex;
-        justify-content: start;
-        align-items: start;
-        flex-direction: column;
-        width: 800px;
-        padding: 1%;
-        gap: 10px;
-
-        .location-wrapper {
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: start; 
-            gap: 5px; 
-            position: relative;
-            
-            .box {
-                height: fit-content;
-                background: transparent;
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                justify-content: center;
-                gap: 1rem;
-
-                .location {
-                    max-width: fit-content;
-
-                    p {
-                        line-height: .5;
-                    }
-
-                    strong {
-                        line-height: .5;
-                    }
-                }
-
-            }
-
-            .line {
-                width: 2px; 
-                height: 35%; 
-                background: $txt-primary;
-                position: absolute; 
-                left: 12px; 
-                top: 50%; 
-                transform: translate(-100%, -50%);
-                z-index: 1; 
-            }
-
-        }
-
-        .additional-info-wrapper {
-
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            width: 100%;
-
-            .additional-info p {
-                margin-top: 0px;   
-            }
-            
-        }
-
-        .price-breakdown {
-            width: 100%;
-
-            .cost {
-                display: flex;
-                flex-direction: row;
-                justify-content: space-between;
-                align-items: center;
-                width: 100%;
-
-                .cost-price {
-                    font-weight: $font-weight-bold;
-                    color: $header-active;
-                }
-
-                .total-price {
-                    font-weight: $font-weight-bold;
-                    font-size: $font-size-lg;
-                    color: $header-active;
-                }
-            }
-        }
-
-        .pod {
-            width: 20%; 
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        .pod img {
-            max-width: 100%;
-            height: auto;
-        }
-
-
-        
-    }
-    footer {
-        display: flex;
-        justify-content: flex-end;  
-        align-items: center;
-        width: 800px;
-        gap: 1rem;
-        margin: 1rem 1rem 6rem 1rem;
-    }
+  }
 }
 
-.action-button {
+// Button Styles
+.action-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
+.btn-primary, .btn-secondary, .btn-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  border: none;
+  
+  @media (max-width: 768px) {
+    padding: 1rem;
+    font-size: 1rem;
+  }
+  
+  .material-symbols-outlined {
+    font-size: 1.25rem;
+  }
+}
+
+.btn-primary {
+  background: $bg-primary;
+  color: white;
+
+  &:hover {
+    background: color.adjust($bg-primary, $lightness: -10%);
+    transform: translateY(-1px);
+  }
+}
+
+.btn-secondary {
+  background: $bg-light;
+  color: $txt-primary;
+  border: 1px solid $border-color;
+
+  &:hover {
+    background: color.adjust($bg-light, $lightness: -5%);
+  }
+}
+
+.btn-back {
+  background: $bg-light;
+  color: $txt-primary;
+  border: 1px solid $border-color;
+  margin-left: auto;
+
+  &:hover {
+    background: color.adjust($bg-light, $lightness: -5%);
+  }
+}
+
+
+// Main Content Styles
+.main-content {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1.5rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: $txt-primary;
+  
+  .material-symbols-outlined {
+    font-size: 1.25rem;
+    color: $bg-primary;
+  }
+}
+
+// Route Section
+.route-section {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+  
+  @media (max-width: 768px) {
+    padding: 1rem;
+    border-radius: 8px;
+  }
+}
+
+.location-timeline {
+  position: relative;
+  
+  .location-item {
     display: flex;
     align-items: center;
-    gap: 4px; 
-    padding: 7px 14px;
-    border: 2px solid $bg-gray;
+    gap: 1rem;
+    padding: 1.5rem 0;
+    position: relative;
+    
+    &:first-child {
+      padding-top: 0;
+    }
+    
+    &:last-child {
+      padding-bottom: 0;
+    }
+    
+    .location-marker {
+      flex-shrink: 0;
+      z-index: 2;
+      background: white;
+      padding: 2px;
+      
+      .material-symbols-outlined {
+        font-size: 1.5rem;
+        color: $bg-primary;
+      }
+    }
+    
+    .location-details {
+      flex: 1;
+      
+      h4 {
+        margin: 0 0 0.5rem 0;
+        font-size: 1rem;
+        font-weight: 600;
+        color: $txt-primary;
+      }
+      
+      .address {
+        margin: 0 0 0.25rem 0;
+        color: $txt-primary;
+        font-weight: 500;
+      }
+      
+      .contact {
+        margin: 0;
+        color: #6b7280;
+        font-size: 0.875rem;
+      }
+    }
+  }
+  
+  .route-line {
+    position: absolute;
+    left: 11px;
+    top: 1.5rem;
+    height: calc(100% - 3rem);
+    width: 2px;
+    background: $bg-primary;
+    z-index: 1;
+  }
+}
+
+// Info Section
+.info-section {
+  margin-bottom: 2rem;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.info-card {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+  
+  @media (max-width: 768px) {
+    padding: 1rem;
+    border-radius: 8px;
+  }
+  
+  h4 {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  
+  p {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 500;
     color: $txt-primary;
-    border-radius: 3px;
-    font-size: $font-size-xs;
-    background-color: $bg-light;
-    cursor: pointer;
-
+  }
 }
 
-
-.action-button:hover {
-    border-color: $bg-primary;
-    color: $bg-primary;
+// Price Section
+.price-section {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+  
+  @media (max-width: 768px) {
+    padding: 1rem;
+    border-radius: 8px;
+  }
 }
 
-.header-icon {
-    font-size: $font-size-xs;
-}
-
-.footer-icon {
-    font-size: $font-size-md;
-}
-
-.body-icon {
-    font-size: $font-size-xl;
-    color: $bg-primary;
-}
-
-.cost {
+.price-list {
+  .price-item {
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #f3f4f6;
+    
+    &:last-child {
+      border-bottom: none;
+    }
+    
+    span:first-child {
+      color: $txt-primary;
+    }
+    
+    .price {
+      font-weight: 600;
+      color: $txt-primary;
+    }
+    
+    &.subtotal {
+      border-top: 2px solid $border-color;
+      margin-top: 0.5rem;
+      padding-top: 1rem;
+      
+      .price {
+        color: $bg-primary;
+        font-size: 1.125rem;
+      }
+    }
+    
+    &.total {
+      border-top: 2px solid $bg-primary;
+      margin-top: 0.5rem;
+      padding-top: 1rem;
+      font-weight: 600;
+      
+      .price {
+        color: $bg-primary;
+        font-size: 1.25rem;
+      }
+    }
+  }
+}
+
+// POD Section
+.pod-section {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+  text-align: center;
+  
+  @media (max-width: 768px) {
+    padding: 1rem;
+    border-radius: 8px;
+  }
+}
+
+.pod-image {
+  max-width: 300px;
+  margin: 0 auto;
+  
+  img {
     width: 100%;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  }
 }
 
-h3 {
-    color: $txt-primary;
-    margin-bottom: 5px;
-}
-strong {
-    color: $txt-primary;
-    margin-bottom: 5px;
+// Footer
+.footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: white;
+  padding: 1rem;
+  box-shadow: 0 -2px 4px -1px rgba(0, 0, 0, 0.1);
+  border-top: 1px solid #e5e7eb;
+  z-index: 100;
+  
+  @media (max-width: 768px) {
+    padding: 0.75rem;
+  }
 }
 
-.action-container {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-}
-
+// No Data State
 .no-record {
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+}
+
+.no-data-content {
+  text-align: center;
+  
+  .no-data-icon {
+    font-size: 4rem;
+    color: #d1d5db;
+    margin-bottom: 1rem;
+  }
+  
+  h2 {
+    margin: 0 0 0.5rem 0;
+    color: #374151;
+  }
+  
+  p {
+    margin: 0;
+    color: #6b7280;
+  }
+}
+
+// Animations
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+// Skeleton Loader Styles
+.skeleton-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  animation: skeleton-pulse 1.5s ease-in-out infinite alternate;
+}
+
+.skeleton-header {
+  margin-bottom: 2rem;
+  
+  .skeleton-status-card {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    margin-bottom: 1rem;
+    
+    @media (max-width: 768px) {
+      padding: 1rem;
+      border-radius: 8px;
+    }
+    
+    .skeleton-indicator {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1rem;
+      
+      .skeleton-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: #e2e8f0;
+      }
+      
+      .skeleton-text {
+        flex: 1;
+        
+        .skeleton-line {
+          margin-bottom: 0.5rem;
+        }
+      }
+    }
+  }
+  
+  .skeleton-content {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    
+    @media (max-width: 768px) {
+      padding: 1rem;
+      border-radius: 8px;
+    }
+    
+    .skeleton-line {
+      margin: 0 auto 1rem auto;
+    }
+    
+    .skeleton-buttons {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      margin-top: 1.5rem;
+      
+      @media (max-width: 768px) {
+        flex-direction: column;
+      }
+    }
+  }
+}
+
+.skeleton-main {
+  max-width: 900px;
+  margin: 0 auto;
+  
+  .skeleton-section {
+    background: white;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+    margin-bottom: 2rem;
+    
+    @media (max-width: 768px) {
+      padding: 1rem;
+      border-radius: 8px;
+    }
+  }
+  
+  .skeleton-timeline {
+    margin-top: 1.5rem;
+    
+    .skeleton-location {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1.5rem 0;
+      
+      &:first-child {
+        padding-top: 0;
+      }
+      
+      &:last-child {
+        padding-bottom: 0;
+      }
+      
+      .skeleton-marker {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: #e2e8f0;
+        flex-shrink: 0;
+      }
+      
+      .skeleton-details {
+        flex: 1;
+        
+        .skeleton-line {
+          margin-bottom: 0.5rem;
+        }
+      }
+    }
+  }
+  
+  .skeleton-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+    
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr;
+    }
+  }
+  
+  .skeleton-card {
+    background: white;
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+    
+    @media (max-width: 768px) {
+      padding: 1rem;
+      border-radius: 8px;
+    }
+    
+    .skeleton-line {
+      margin-bottom: 0.5rem;
+    }
+  }
+  
+  .skeleton-price-list {
+    margin-top: 1.5rem;
+    
+    .skeleton-price-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 0;
+      border-bottom: 1px solid #f3f4f6;
+      
+      &:last-child {
+        border-bottom: none;
+      }
+      
+      .skeleton-line {
+        margin: 0;
+      }
+    }
+  }
+}
+
+.skeleton-button {
+  height: 44px;
+  width: 140px;
+  border-radius: 8px;
+  background: #e2e8f0;
+}
+
+.skeleton-line {
+  height: 16px;
+  background: #e2e8f0;
+  border-radius: 4px;
+  
+  &.skeleton-line-sm {
+    width: 100px;
+    height: 14px;
+  }
+  
+  &.skeleton-line-md {
+    width: 200px;
+    height: 16px;
+  }
+  
+  &.skeleton-line-lg {
+    width: 300px;
+    height: 20px;
+  }
+}
+
+@keyframes skeleton-pulse {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.6;
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 480px) {
+  .details-wrapper {
+    padding: 0.25rem;
+  }
+  
+  .status-header .status-card,
+  .status-header .header-content,
+  .route-section,
+  .price-section,
+  .pod-section {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  .driver-info .driver-details {
+    text-align: left;
+    
+    p {
+      font-size: 0.8rem;
+    }
+  }
+  
+  .action-buttons {
+    gap: 0.5rem;
+  }
+  
+  .btn-primary, .btn-secondary {
+    padding: 0.875rem 1rem;
+    font-size: 0.9rem;
+  }
 }
 </style>

--- a/includes/class_lalamove_shortcode.php
+++ b/includes/class_lalamove_shortcode.php
@@ -435,7 +435,7 @@ public function render_qr_content() {
                     }
                 }
             </style>
-        <div class="delivery-details w-100 h-100 d-flex flex-column justify-content-center " style="background-color: #FCFCFC; padding: 12rem; border: 1px solid #D9D9D9; margin-bottom: 20px;">
+        <div class="delivery-details w-100 h-100 d-flex flex-column justify-content-center " style="background-color: #FCFCFC; padding: 1rem; border: 1px solid #D9D9D9; margin-bottom: 20px;">
 
         <button onclick="window.history.back();" 
             onmouseover="this.style.border="1px solid black";" 

--- a/includes/utility-functions.php
+++ b/includes/utility-functions.php
@@ -1,4 +1,5 @@
 <?php
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
 if (!defined('ABSPATH'))
     exit;
@@ -21,47 +22,63 @@ function get_shop_logo(){
 	}
 }
 
-function get_delivery_details($order_id){
-
-	global $wpdb;
-
-
+function get_delivery_details($order_id) {
+    global $wpdb;
 
     $orders_table = $wpdb->prefix . 'wc_lalamove_orders';
-	$transaction_table = "{$wpdb->prefix}wc_lalamove_transaction";
+    $transaction_table = "{$wpdb->prefix}wc_lalamove_transaction";
 
-	// Use INNER JOIN to fetch data from both tables
-	$delivery_data = $wpdb->get_row($wpdb->prepare(
-		"SELECT orders.*, transactions.* 
-		FROM {$orders_table} orders 
-		INNER JOIN {$transaction_table} transactions
-		ON orders.transaction_id = transactions.transaction_id
-		WHERE orders.wc_order_id = %d",
-		intval($order_id)
-	));
+    try {
+        // Start "transaction" — not real SQL transaction, but logical grouping
+        $wpdb->query('START TRANSACTION');
 
-	$order_id = $delivery_data->wc_order_id;
-	$customer_name = $delivery_data->ordered_by;
-	$delivery_id = $delivery_data->lalamove_order_id;
-	$ordered_on = $delivery_data->ordered_on;
+        // Prepare and execute query
+        $delivery_data = $wpdb->get_row($wpdb->prepare(
+            "SELECT orders.*, transactions.* 
+            FROM {$orders_table} orders 
+            INNER JOIN {$transaction_table} transactions
+            ON orders.transaction_id = transactions.transaction_id
+            WHERE orders.wc_order_id = %d",
+            intval($order_id)
+        ));
 
-	// Create a DateTime object
-	$date = new DateTime($ordered_on);
-	$ordered_on = $date->format('F j, Y');
+        if (!$delivery_data) {
+            throw new Exception("No delivery data found for order ID: $order_id");
+        }
 
-	$drop_off_location = $delivery_data->drop_off_location;
+        // Extract and format fields
+        $order_id = $delivery_data->wc_order_id;
+        $raw_name = $delivery_data->ordered_by;
+        preg_match('/^([^\(]+)/', $raw_name, $matches);
+        $customer_name = trim($matches[1]);
 
-	$delivery_details = [
-		"order_id" => $order_id,
-		"customer_name" => $customer_name,
-		"delivery_id" => $delivery_id,
-		"ordered_on" => $ordered_on,
-		"drop_off_location" => $drop_off_location,
-	];
+        $delivery_id = $delivery_data->lalamove_order_id;
+        $ordered_on = (new DateTime($delivery_data->ordered_on))->format('F j, Y');
+        $drop_off_location = $delivery_data->drop_off_location;
 
-	return $delivery_details;
+        // Commit "transaction"
+        $wpdb->query('COMMIT');
 
+        return [
+            "order_id" => $order_id,
+            "customer_name" => $customer_name,
+            "delivery_id" => $delivery_id,
+            "ordered_on" => $ordered_on,
+            "drop_off_location" => $drop_off_location,
+        ];
+
+    } catch (Exception $e) {
+        // Rollback "transaction"
+        $wpdb->query('ROLLBACK');
+
+        // Log error
+        error_log("Delivery details error: " . $e->getMessage());
+
+        // Return fallback or null
+        return null;
+    }
 }
+
 
 function get_weight_unit() {
     // Fetch weight unit from WooCommerce settings
@@ -72,47 +89,71 @@ function get_weight_unit() {
 
 
 function get_order_details($order_id) {
-    $order = wc_get_order($order_id);
+    global $wpdb;
 
-    if (!$order) {
-        return "Invalid Order ID";
-    }
+    try {
+        $wpdb->query('START TRANSACTION');
 
-    // Initialize arrays and variables
-    $product_details = [];
-    $total_weight = 0;
-    $total_quantity = 0;
+        $order = wc_get_order($order_id);
 
-    // Loop through the order items
-    foreach ($order->get_items() as $item) {
-        $product = $item->get_product();
-
-        if ($product) {
-            // Fetch quantity and weight
-            $quantity = $item->get_quantity();
-            $weight = $product->get_weight();
-
-            // Accumulate totals
-            $total_weight += floatval($weight) * $quantity;
-            $total_quantity += $quantity;
-
-            // Store individual product details
-            $product_details[] = [
-                'product_name' => $product->get_name(),
-                'quantity' => $quantity,
-                'weight' => $weight,
-            ];
+        if (!$order) {
+            throw new Exception("Invalid Order ID: $order_id");
         }
+
+        // Initialize arrays and variables
+        $product_details = [];
+        $total_weight = 0;
+        $total_quantity = 0;
+
+        // Loop through the order items
+        foreach ($order->get_items() as $item) {
+            $product = $item->get_product();
+
+            if ($product) {
+                $quantity = $item->get_quantity();
+                $weight = $product->get_weight();
+
+                $total_weight += floatval($weight) * $quantity;
+                $total_quantity += $quantity;
+
+                $product_details[] = [
+                    'product_name' => $product->get_name(),
+                    'quantity' => $quantity,
+                    'weight' => $weight,
+                ];
+            }
+        }
+
+        // Add total details to the result
+        $product_details['totals'] = [
+            'total_quantity' => $total_quantity,
+            'total_weight' => $total_weight,
+        ];
+
+        // Commit "transaction"
+        $wpdb->query('COMMIT');
+
+        return $product_details;
+
+    } catch (Exception $e) {
+        // Rollback "transaction"
+        $wpdb->query('ROLLBACK');
+
+        // Log error
+        error_log("Order details error: " . $e->getMessage());
+
+        // Return fallback
+        return [
+            'error' => true,
+            'message' => $e->getMessage(),
+            'totals' => [
+                'total_quantity' => 0,
+                'total_weight' => 0,
+            ]
+        ];
     }
-
-    // Add total details to the result
-    $product_details['totals'] = [
-        'total_quantity' => $total_quantity,
-        'total_weight' => $total_weight,
-    ];
-
-    return $product_details;
 }
+
 
 function format_address($text, $max_length = 45) {
     return wordwrap(htmlspecialchars($text), $max_length, "<br>", true);
@@ -139,18 +180,21 @@ function print_waybill($order_ids, $bulk_printing = false) {
 
 	foreach($order_ids as $order_id){
 
-		// QR code generation
-		$qrData = get_site_url().'/waybill-qr/?order_id='. $order_id;
-		$qrCode = new Mpdf\QrCode\QrCode($qrData);
-		$output = new Mpdf\QrCode\Output\Png();
-		$qrCodePng = $output->output($qrCode, 100, [255, 255, 255], [0, 0, 0]);
-		$qrCodeBase64 = base64_encode($qrCodePng);
-		error_log("Order ID: " . print_r($order_id, true));
-		$delivery_data = get_delivery_details($order_id);
-		$order_details = get_order_details($order_id);
-		$wc_order_id = (int)$order_id;
+	// QR code generation
+	$qrData = get_site_url().'/waybill-qr/?order_id='. $order_id;
+	$qrCode = new Mpdf\QrCode\QrCode($qrData);
+	$output = new Mpdf\QrCode\Output\Png();
+	$qrCodePng = $output->output($qrCode, 100, [255, 255, 255], [0, 0, 0]);
+	$qrCodeBase64 = base64_encode($qrCodePng);
+	error_log("Order ID: " . print_r($order_id, true));
+	$delivery_data = get_delivery_details($order_id);
+	$order_details = get_order_details($order_id);
+	$wc_order_id = (int)$order_id;
 
-
+	// Skip if either is empty or contains an error
+    if (empty($delivery_data) || empty($order_details) || !empty($order_details['error'])) {
+        continue;
+    }
 
 	// HTML content
 	$html = '
@@ -243,7 +287,7 @@ function print_waybill($order_ids, $bulk_printing = false) {
 				<td colspan="1" class="rotate">BUYER</td>
 				<td colspan="3" class="content-cell">
 					<div style="max-height: 33mm; overflow: hidden;">
-						<strong>buyer123</strong><br><br>
+						<strong>'. $delivery_data['customer_name'] .'</strong><br><br>
 						'. wordwrap($delivery_data['drop_off_location'], 45, "<br>", true) .'
 					</div>
 				</td>
@@ -416,7 +460,7 @@ function short_code_delivery_details($lalamove_order_id, $shareLink, $podImage, 
 		</div>';
 	}
 
-	if($order_status != 'completed' ||$order_status != 'cancelled') {
+	if($order_status !== 'completed' && $order_status !== 'cancelled') {
 		$confirmation_button = '
 		<form class="mt-4" method="post">
 			<input type="hidden" name="order_id" value="'. esc_attr($order_id) .'">
@@ -517,3 +561,25 @@ function get_lala_id($order_id) {
         return null;
     }
 }
+
+
+
+/**
+ * Retrieves the correct WooCommerce screen ID based on HPOS support.
+ */
+function get_screen_id() 
+{
+
+	return class_exists('\\Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\CustomOrdersTableController') &&
+	wc_get_container()->get(CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
+	? wc_get_page_screen_id('shop-order')
+	: 'shop_order';
+}
+
+/**
+ * Retrieves the WooCommerce order object safely.
+ */
+function get_order_object($post) {
+	return is_a($post, 'WP_Post') ? wc_get_order($post->ID) : $post;
+}
+


### PR DESCRIPTION
- Added `push_pos_order_to_lalamove` method in `Class_Lalamove_Model` to handle pushing WooCommerce orders to Lalamove.
- Introduced a custom meta box in the WooCommerce order edit screen to send orders to Lalamove.
- Enqueued necessary scripts for the meta box functionality.
- Updated utility functions for better order handling and screen ID retrieval.
- Adjusted styles in the shortcode rendering for better UI.
- Fixed logical condition for order status checks in utility functions.
- Fixed naming and empty lalamove in the waybill as it prevents the waybill from being printed
- Fixed quotation malfunction on POD and schedules on checkout lalamove modal
- Included find my location button and geocoder input for user to locate their or a location easily in the checkout lalamove modal